### PR TITLE
Fix `vkuTestBasicCube` not compiling

### DIFF
--- a/run/basic_cube.c
+++ b/run/basic_cube.c
@@ -80,7 +80,7 @@ int main()
     VkDeviceSize sizes[] = {sizeof(cubeVertices)};
     vkuCopyBuffer(context->memoryManager, &stagingBuffer, &vertexBuffer, sizes, 1);
 
-    vkuDestroyVertexBuffer(stagingBuffer, context->memoryManager);
+    vkuDestroyVertexBuffer(stagingBuffer, context->memoryManager, VK_TRUE);
 
     VkuRenderStageCreateInfo renderStageCreateInfo = {
         .msaaSamples = vkuContextGetMaxSampleCount(context),
@@ -197,7 +197,7 @@ int main()
     vkuDestroyTextureSampler(context, sampler);
     vkuDestroyTexture2DArray(context, texArray);
     vkuDestroyRenderStage(renderStage);
-    vkuDestroyVertexBuffer(vertexBuffer, context->memoryManager);
+    vkuDestroyVertexBuffer(vertexBuffer, context->memoryManager, VK_TRUE);
     vkuDestroyPresenter(presenter);
     vkuDestroyContext(context);
 


### PR DESCRIPTION
The following commit should allow for the `basic_cube.c` file to be compiled again, resolving [this issue](https://github.com/nelo-dev/vkutils/issues/2).