### PR TITLE
Add CMake build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@
 
 # Precompiled shaders
 *.spv
+
+# Common build directories
+[Bb]in/*
+[Bb]uild/*
+[Oo]ut/*
+[Rr]esult/*
+[Tt]arget/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.14)
+project(vkutils)
+
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(COMPILE_WARNING_AS_ERROR ON)
+set(LINKER_LANGUAGE C)
+
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -g")
+
+option(BUILD_EXAMPLES OFF)
+option(BUILD_SHARED OFF)
+option(SYSTEM_LIBRARIES OFF)
+
+if (CMAKE_BUILD_TYPE EQUAL "Debug")
+    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS_DEBUG})
+    set(CMAKE_LINKER_FLAGS ${CMAKE_LINKER_FLAGS_DEBUG})
+endif()
+
+set(SOURCE_FILES 
+    src/vkutils.c
+    lib/vk_mem_alloc/vk_mem_alloc.cpp
+)
+
+set(HEADER_FILES
+    lib/stb/stb_image.h
+    lib/vk_mem_alloc/vk_mem_alloc.h
+    src/vkutils.h
+)
+
+macro(build_library LINKING_TYPE)
+    message("Building as ${LINKING_TYPE}")
+    add_library(vkutils ${LINKING_TYPE} ${SOURCE_FILES} ${HEADER_FILES})
+endmacro()
+
+find_package(Vulkan REQUIRED)
+find_package(cglm REQUIRED)
+find_package(glfw3 REQUIRED)
+
+if(SYSTEM_LIBRARIES)
+    # Find and use system's `stb` and `VulkanMemoryAllocator` files.
+endif()
+
+if(BUILD_SHARED)
+    build_library(SHARED)
+else()
+    build_library(STATIC)
+
+    target_link_libraries(vkutils        
+        Vulkan::Vulkan
+        cglm::cglm
+        glfw
+        -lm
+    )
+endif()
+
+if(BUILD_EXAMPLES)
+    add_subdirectory(run/)
+endif()
+
+include_directories(
+    ${Vulkan_INCLUDE_DIR}
+    ${cglm_INCLUDE_DIR}
+    ${glfw3_INCLUDE_DIR}
+)
+
+target_include_directories(vkutils PUBLIC 
+    src/ 
+)
+

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -1,3 +1,11 @@
+set(SHADER_FILES
+	${CMAKE_SOURCE_DIR}/run/shader/post.frag
+	${CMAKE_SOURCE_DIR}/run/shader/post.vert
+	${CMAKE_SOURCE_DIR}/run/shader/simple.frag
+	${CMAKE_SOURCE_DIR}/run/shader/simple.vert
+	${CMAKE_SOURCE_DIR}/run/shader/staticpost.frag
+)
+
 macro(link target)
     target_link_libraries(${target}
         Vulkan::Vulkan
@@ -8,11 +16,38 @@ macro(link target)
     )
 endmacro()
 
+add_custom_target(shaders)
+
 add_executable(vkuTestBasicCube basic_cube.c)
 add_executable(vkuTestPostProcessingCube postprocessing_cube.c)
+
+add_dependencies(vkuTestBasicCube shaders)
+add_dependencies(vkuTestPostProcessingCube shaders)
 
 link(vkuTestBasicCube)
 link(vkuTestPostProcessingCube)
 
 file(COPY ${CMAKE_SOURCE_DIR}/run/resources 
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+
+make_directory(${CMAKE_CURRENT_BINARY_DIR}/shader)
+
+foreach(FILE ${SHADER_FILES})
+  get_filename_component(FILE_WE ${FILE} NAME_WE)
+
+  if(${FILE} MATCHES "(vert)")
+	  set(OUTPUT_FILE "${FILE_WE}_vert.spv")
+  elseif(${FILE} MATCHES "(frag)")
+	  set(OUTPUT_FILE "${FILE_WE}_frag.spv")
+  endif()
+
+  message(${OUTPUT_FILE})
+  
+  add_custom_command(TARGET shaders
+	COMMAND glslc ${FILE} -o "${CMAKE_CURRENT_BINARY_DIR}/shader/${OUTPUT_FILE}"
+        MAIN_DEPENDENCY ${FILE}
+	COMMENT "Compiling ${FILE} with glslc"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        VERBATIM)
+endforeach(FILE)
+

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -15,4 +15,4 @@ link(vkuTestBasicCube)
 link(vkuTestPostProcessingCube)
 
 file(COPY ${CMAKE_SOURCE_DIR}/run/resources 
-    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/resources)
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -1,0 +1,18 @@
+macro(link target)
+    target_link_libraries(${target}
+        Vulkan::Vulkan
+        cglm::cglm
+        glfw
+        vkutils
+        -lm
+    )
+endmacro()
+
+add_executable(vkuTestBasicCube basic_cube.c)
+add_executable(vkuTestPostProcessingCube postprocessing_cube.c)
+
+link(vkuTestBasicCube)
+link(vkuTestPostProcessingCube)
+
+file(COPY ${CMAKE_SOURCE_DIR}/run/resources 
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/resources)


### PR DESCRIPTION
This pull request intends to add CMake build support as discussed in [issue #4](https://github.com/nelo-dev/vkutils/issues/4).

Building can be done with the following commands:
```sh
cmake \
    -B target/release \
    -D CMAKE_BUILD_TYPE=Release \
    -D BUILD_EXAMPLES=ON 
cmake --build target/release -j$(nproc)
```
This currently does not compile shaders, however, and they must compiled manually. Test binaries will be located in `target/release/run/`, following the given command.

## To-do
- [x] Fix `run/resources` copying into `${CMAKE_CURRENT_BINARY_DIR}/resources/resources` 
- [x] Create a build task to compile shaders.
- [ ] Allow system-level `stb` and `VulkanMemoryAllocator` libraries to be used.
- [ ] Create a `Makefile` to abstract away CMake commands.
- [ ] Rewrite build documentation.